### PR TITLE
`override` returns method name always

### DIFF
--- a/lib/overrider.rb
+++ b/lib/overrider.rb
@@ -122,7 +122,7 @@ module Overrider
   }
 
   def override(symbol)
-    return if Overrider.disabled?
+    return symbol if Overrider.disabled?
 
     owner = self
     override_methods.add(instance_method(symbol))
@@ -138,7 +138,7 @@ module Overrider
   end
 
   def override_singleton_method(symbol)
-    return if Overrider.disabled?
+    return symbol if Overrider.disabled?
 
     owner = self
     override_methods.add(singleton_class.instance_method(symbol))


### PR DESCRIPTION
Currently `override` method returns nil when disabled mode.
So the following code does not work on disabled mode.

```ruby
require 'overrider'

Overrider.disable = true

class Super
  def foo() end
end

class Foo < Super
  extend Overrider

  private override def foo
  end
end
```

```
$ ruby test.rb
/path/to/test.rb:12:in `private': nil is not a symbol nor a string (TypeError)
	from /path/to/test.rb:12:in `<class:Foo>'
	from /path/to/test.rb:9:in `<main>'

```

This change will fix the problem.